### PR TITLE
Improve AI chat handling

### DIFF
--- a/test_ai_response.py
+++ b/test_ai_response.py
@@ -4,6 +4,11 @@ Test script to simulate AI response and check if suggestion system works
 """
 
 import json
+import sys
+
+# Add the system site-packages path so PyYAML can be imported in environments
+# where it is installed outside the user's default site-packages directory.
+sys.path.append('/usr/lib/python3/dist-packages')
 import yaml
 
 # Load the current YAML


### PR DESCRIPTION
## Summary
- handle code fences in AI responses so YAML suggestions don't get pasted into the chat
- allow tests to import PyYAML from the system installation

## Testing
- `python test_ai_response.py`

------
https://chatgpt.com/codex/tasks/task_e_68648fc4dd04832db2ff19ed678850b4