### PR TITLE
Improve preview performance

### DIFF
--- a/simple_yaml_editor.py
+++ b/simple_yaml_editor.py
@@ -1229,10 +1229,13 @@ EDITOR_HTML = """
         
         function saveAndRender() {
             if (isRendering) return;
-            
+
             isRendering = true;
             setStatus('Rendering...', 'info');
-            showPreviewMessage('🔄 Rendering CV...');
+
+            if (!pdfPreview.src) {
+                showPreviewMessage('🔄 Rendering CV...');
+            }
             
             const yamlContent = editor.getValue();
             


### PR DESCRIPTION
## Summary
- keep current PDF visible during re-renders
- show loading message only when no previous preview is available

## Testing
- `python test_ai_response.py` *(fails: PyYAML is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68649609ee74832dbc0359ba2fa5d6d7